### PR TITLE
Minor changes to README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 **ADS-B funhouse**
 ==========
 
-This is a collection of Python scripts for playing with [ADS-B](https://en.wikipedia.org/wiki/Automatic_dependent_surveillance-broadcast) data from [dump1090](https://github.com/antirez/dump1090). You will need an [rtl-sdr](http://sdr.osmocom.org/trac/wiki/rtl-sdr) receiver to join the fun.
+This is a collection of Python scripts for playing with [ADS-B](https://en.wikipedia.org/wiki/Automatic_dependent_surveillance-broadcast) data from [dump1090](https://github.com/antirez/dump1090). You will need an [rtl-sdr](http://sdr.osmocom.org/trac/wiki/rtl-sdr) receiver to join the fun.  You will also need the Paho-MQTT client for your installed version of Python (usually installed with the command `pip install paho-mqtt`).
 
 ## adsbclient.py
 
 This is yet another ADS-B decoder written in Python. It feeds off port 30003 on your dump1090 receiver and publishes each message to your MQTT broker. It is invoked using:
 
-`% adsbclient.py -m <dump1090 host> -H <MQTT host> -r <radar name> -pdb PlaneBase.sqb`
+`% adsbclient.py -H <dump1090 host> -m <MQTT host> -r <radar name> -mdb myplanedb`
 
 The MQTT publish topic is `/adsb/<radar name>/json` and the JSON data contains the following fields:
 
@@ -27,9 +27,9 @@ The MQTT publish topic is `/adsb/<radar name>/json` and the JSON data contains t
 | lat          | Latitude                                  | 55.29126
 | verticalRate | Vertical climb/descend rate [ft/min]      | 2240
 
-The aircraft's operator, type and registration are not available in the ADS-B data the aircraft transmits and needs to be pulled from another data source. One excellent source is [PlaneBaseNG](http://planebase.biz) with about 147k aircrafts and can be downloaded [here](http://planebase.biz/bstnsqb). Another source is [Virtual Radar Server](http://www.virtualradarserver.co.uk/Files/BaseStation.zip) with ~77k aircrafts, mainly UK ones.
+The aircraft's operator, type and registration are not available in the ADS-B data the aircraft transmits and needs to be pulled from another data source. One excellent source is [PlaneBaseNG](http://planebase.biz) with about 147k aircraft and can be downloaded [here](http://planebase.biz/bstnsqb). Another source is [Virtual Radar Server](http://www.virtualradarserver.co.uk/Files/BaseStation.zip) with ~77k aircraft, mainly UK ones.
 
-If you often see aircrafts that are not found in the above databases you can add them manually to your own database and tell adsbclient.py to search it too using the argument `--myplanedb`. Invoking adsbclient.py with a non existent database will create and initialize the database in the specified file.
+If you often see aircraft that are not found in the above databases you can add them manually to your own database and tell adsbclient.py to search it too using the argument `--myplanedb`. Invoking adsbclient.py with a non existent database will create and initialize the database in the specified file.
 
 The following arguments are supported by adsbclient.py:
 
@@ -104,7 +104,7 @@ The following arguments are supported by:
 | --help      | well...
 | --mqtt-host | MQTT broker hostname
 | --mqtt-port | MQTT broker port number (default 1883)
-| --distance  | max distance in kilometers, the color will be black (#000000) for aircrafts beyond this distance
+| --distance  | max distance in kilometers, the color will be black (#000000) for aircraft beyond this distance
 | --topic     | the topic to post color data to
 | --verbose   | Verbose output
 


### PR DESCRIPTION

Johan,

   Just a couple of very minor change suggestions for the README.md file:-

   - Fixed argument list to adsbclient.py in example usage line.

     The example line at the top of the README.md file doesn't currently give the correct arguments; the 1090 host and MQTT host are swapped and the "-pdb" argument doesn't exist.

   - Added "requires Paho-MQTT" in header info.

     I'm not a python guy.  Does the try: ...except ImportError: still work when using "as"?

   - Corrected all instances of "aircrafts" to "aircraft".

     While I was at it, I just did a global change on "aircrafts" to "aircraft" (English is so damned inconsistent!  I live in Japan and there's nothing like struggling with another language to make you realize just how quirky your own is).

   Best wishes from Nagano-ken,

                                       -John-

