### PR TITLE
minor fixes for reading SBS-1 streams from data.adsbhub.org

### DIFF
--- a/flighttracker.py
+++ b/flighttracker.py
@@ -388,8 +388,8 @@ class FlightTracker(object):
                 return None
             while buffering:
                 if "\n" in buffer:
-                    (line, buffer) = buffer.split("\r\n", 1)
-                    yield line
+                    (line, buffer) = buffer.split("\n", 1)
+                    yield line.rstrip("\r")
                 else:
                     try:
                         more = self.__dump1090_sock.recv(4096)

--- a/sbs1.py
+++ b/sbs1.py
@@ -77,8 +77,8 @@ def parse(msg: str) -> Dict[str, Union[str, int, float, bool, datetime]]:
         if sbs1["callsign"]:
             sbs1["callsign"] = sbs1["callsign"].rstrip()
         sbs1["altitude"] = __parseInt(parts, 11)
-        sbs1["groundSpeed"] = __parseInt(parts, 12)
-        sbs1["track"] = __parseInt(parts, 13)
+        sbs1["groundSpeed"] = __parseFloat(parts, 12)
+        sbs1["track"] = __parseFloat(parts, 13)
         sbs1["lat"] = __parseFloat(parts, 14)
         sbs1["lon"] = __parseFloat(parts, 15)
         sbs1["verticalRate"] = __parseInt(parts, 16)


### PR DESCRIPTION
flighttracker.py can be used with a feed from data.adsbhub.org port 5002 as well (provided you feed them and have registered your originating IP address with them)

this PR handles two minor nits:

- adsbhub sends groundSpeed and track as floats so parse accordingly
- adsbhub just uses newlines to separate transmission messages, so handle both the nl and cr/nl case